### PR TITLE
Filter bot messages when storing history

### DIFF
--- a/src/update.ts
+++ b/src/update.ts
@@ -24,6 +24,7 @@ export function getTextMessage(update: any) {
 
 export async function recordMessage(msg: any, env: Env) {
   if (!msg) return;
+  if (msg.from?.is_bot) return;
   const chatId = msg.chat.id;
   const userId = msg.from?.id || 0;
   const username = msg.from?.username || `id${userId}`;


### PR DESCRIPTION
## Summary
- ensure recordMessage doesn't store messages from bots

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688d22b74fa4832e84f19b61e8d3c00d
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Stopped storing messages from bots in the message history to keep records clean.

<!-- End of auto-generated description by cubic. -->

